### PR TITLE
feat(hackathon): scan Jira tickets and create PRs for them

### DIFF
--- a/subcommands/help
+++ b/subcommands/help
@@ -3,9 +3,9 @@
 USAGE: slopify [SUBCOMMAND]
 
 SUBCOMMANDS:
-  help        - Prints this message 
-  pick-ticket - Creates a PR based on a jira ticket
-  pick-comment -Changes your local code based on a github comment
+  help         - Prints this message
+  pick-ticket  - Creates a PR based on a jira ticket
+  pick-comment - Changes your local code based on a github comment
+  scan-tickets - Scan Jira tickets with the `slopify` label and create PRs for them
 {%- endset %}
 {{print(help)}}
-

--- a/subcommands/pick-comment
+++ b/subcommands/pick-comment
@@ -80,7 +80,7 @@ gh pr diff
 ```
 
 # Output
-Print whole changed files.
+Print whole changed files. Output each changed file as a separate code block with the filename on top.
 
 {%- endset %}
 
@@ -88,8 +88,7 @@ Print whole changed files.
 
 {% set changes_json|prompt("gemini/gemini-2.5-flash-preview-05-20")|code|json %}
 # Task
-Convert the given input to a JSON dict where they keys are a filename and the values the files content.
-
+Convert the given input to a JSON dictionary where the keys are the names of changed files and the values are content of the changed files.
 ```
 {{changes}}
 ```

--- a/subcommands/pick-ticket
+++ b/subcommands/pick-ticket
@@ -199,7 +199,7 @@ git commit -m {{ commit.splitlines()[0]|escape }}
 
   # These are the PR changes
   {% filter run(label=True) %}
-    git diff $(git merge-base --fork-point dev)
+    git diff $(git merge-base --fork-point test)
   {% endfilter %}
   /no_think
 {% endset %}

--- a/subcommands/pick-ticket
+++ b/subcommands/pick-ticket
@@ -9,14 +9,10 @@
 {{ print("Config:", conf) }}
 
 #
-# Load the ticket from the args, if set
+# Let user pick a ticket if none passed as argument
 #
 {% set ticket_id=input.split()[1] %}
 {% if not ticket_id %}
-
-#
-# Let user pick a ticket
-#
 {% set ticket_id|run()|trim("\n") %}
 jira issues list \
   --plain \

--- a/subcommands/pick-ticket
+++ b/subcommands/pick-ticket
@@ -6,8 +6,13 @@
 # Load config
 #
 {% set conf = loadini("~/.slopify.ini") %}
-{{print("Config:", conf) }}
+{{ print("Config:", conf) }}
 
+#
+# Load the ticket from the args, if set
+#
+{% set ticket_id=input.split()[1] %}
+{% if not ticket_id %}
 
 #
 # Let user pick a ticket
@@ -22,6 +27,7 @@ fzf  \
   --preview-window=bottom:50% |
 awk '{print $1}'
 {% endset %}
+{% endif %}
 {{ print("Ticket:", ticket_id) }}
 
 #
@@ -197,7 +203,7 @@ git commit -m {{ commit.splitlines()[0]|escape }}
 
   # These are the PR changes
   {% filter run(label=True) %}
-    git diff $(git merge-base --fork-point test)
+    git diff $(git merge-base --fork-point dev)
   {% endfilter %}
   /no_think
 {% endset %}

--- a/subcommands/scan-tickets
+++ b/subcommands/scan-tickets
@@ -1,0 +1,22 @@
+#!/usr/bin/env siesta
+# vim: set ft=jinja
+
+# Scan Jira ticket_ids with the `slopify` label and call the `pick-ticket` subcommand for them
+
+{% set tickets|run()|trim("\n") %}
+jira issues list \
+    --plain \
+    --columns KEY \
+    --no-headers \
+    --label slopify --label frontend
+{% endset %}
+
+{{ print("Found tickets:\n{}".format(tickets)) }}
+
+{% for ticket_id in tickets.split("\n") %}
+{{ print("Processing ticket {}...".format(ticket_id)) }}
+
+{% filter run %}
+slopify pick-ticket {{ ticket_id }}
+{% endfilter %}
+{% endfor %}

--- a/subcommands/scan-tickets
+++ b/subcommands/scan-tickets
@@ -8,7 +8,7 @@ jira issues list \
     --plain \
     --columns KEY \
     --no-headers \
-    --label slopify --label frontend
+    --jql "project IS NOT EMPTY AND labels = slopify"
 {% endset %}
 
 {{ print("Found tickets:\n{}".format(tickets)) }}

--- a/subcommands/scan-tickets
+++ b/subcommands/scan-tickets
@@ -8,7 +8,7 @@ jira issues list \
     --plain \
     --columns KEY \
     --no-headers \
-    --jql "project IS NOT EMPTY AND labels = slopify"
+    --jql 'project IS NOT EMPTY AND labels = "slopify" AND statusCategory = "To Do" AND development[pullrequests].open = 0'
 {% endset %}
 
 {{ print("Found tickets:\n{}".format(tickets)) }}

--- a/subcommands/scan-tickets
+++ b/subcommands/scan-tickets
@@ -17,6 +17,6 @@ jira issues list \
 {{ print("Processing ticket {}...".format(ticket_id)) }}
 
 {% filter run %}
-slopify pick-ticket {{ ticket_id }}
+slopify pick-ticket {{ ticket_id }} || echo "Failed to process ticket {{ ticket_id }}." >&2
 {% endfilter %}
 {% endfor %}


### PR DESCRIPTION
This is a result from our Hackathon today.

This PR adds a new command `scan-tickets` that will scan your Jira project for all tickets with the label `slopify`
and create a pull-request for each of them using the `pick-ticket` command.